### PR TITLE
🐛 Don't use patched nerd font in Kitty

### DIFF
--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -6,10 +6,10 @@
 #: individual font faces and even specify special fonts for particular
 #: characters.
 
-font_family      OperatorMonoLig Nerd Font Light
-bold_font        OperatorMonoLig Nerd Font Book
-italic_font      OperatorMonoLig Nerd Font Light Italic
-bold_italic_font OperatorMonoLig Nerd Font Book Italic
+font_family      Operator Mono Light
+bold_font        Operator Mono Book
+italic_font      Operator Mono Light Italic
+bold_italic_font Operator Mono Book Italic
 
 #: You can specify different fonts for the bold/italic/bold-italic
 #: variants. To get a full list of supported fonts use the `kitty
@@ -67,6 +67,7 @@ font_size 14.0
 #: accordingly.
 
 # symbol_map U+E0A0-U+E0A3,U+E0C0-U+E0C7 PowerlineSymbols
+symbol_map U+23FB-U+23FE,U+2665,U+26A1,U+2B58,U+E000-U+E00A,U+E0A0-U+E0A3,U+E0B0-U+E0C8,U+E0CA,U+E0CC-U+E0D2,U+E0D4,U+E200-U+E2A9,U+E300-U+E3E3,U+E5FA-U+E62F,U+E700-U+E7C5,U+F000-U+F2E0,U+F300-U+F31C,U+F400-U+F4A9,U+F500-U+F8FF Symbols Nerd Font
 
 #: Map the specified unicode codepoints to a particular font. Useful
 #: if you need special rendering for some symbols, such as for


### PR DESCRIPTION
[Kitty doesn't like patched fonts. ](https://sw.kovidgoyal.net/kitty/faq/?highlight=nerd%20font#kitty-is-not-able-to-use-my-favorite-font)
- Use normal font
- map symbol to nerd font symbols